### PR TITLE
Add docker compose and Python API service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 pnpm-lock.yaml
 .next
 dist
+pgdata

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+up:
+	docker compose up -d --build
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f
+
+test:
+	docker compose run --rm api pytest

--- a/README.md
+++ b/README.md
@@ -26,3 +26,29 @@ Additional scripts:
 pnpm build # build all packages
 pnpm lint  # run ESLint across the monorepo
 ```
+
+## Docker quickstart
+
+Start the API, PostgreSQL and Redis stack with a single command:
+
+```bash
+make up
+```
+
+Stop the containers with:
+
+```bash
+make down
+```
+
+View service logs:
+
+```bash
+make logs
+```
+
+Execute the API test suite:
+
+```bash
+make test
+```

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, TRUX"}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+pytest
+httpx

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_read_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello, TRUX"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.9'
+services:
+  api:
+    build: ./api
+    volumes:
+      - ./api:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+      - redis
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE trux;
+\c trux;
+CREATE SCHEMA IF NOT EXISTS trux_core;


### PR DESCRIPTION
## Summary
- add initialization script and Docker compose setup for api, postgres and redis
- add Python FastAPI app with tests
- provide Makefile shortcuts
- document Docker workflow in README
- ignore local postgres data

## Testing
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68463d6e821483308a6c2d146a07c15e